### PR TITLE
conda recipe updates

### DIFF
--- a/pkg/conda/fastfilters/build.sh
+++ b/pkg/conda/fastfilters/build.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+if [ $(uname) == Darwin ]; then
+    CC=clang
+    CXX=clang++
+    CXXFLAGS="-stdlib=libc++"
+else
+    CC=${PREFIX}/bin/gcc
+    CXX=${PREFIX}bin/g++
+fi
+
 mkdir build_conda
 cd build_conda
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} ..

--- a/pkg/conda/fastfilters/build.sh
+++ b/pkg/conda/fastfilters/build.sh
@@ -5,8 +5,8 @@ if [ $(uname) == Darwin ]; then
     CXX=clang++
     CXXFLAGS="-stdlib=libc++"
 else
-    CC=${PREFIX}/bin/gcc
-    CXX=${PREFIX}bin/g++
+    CC=gcc
+    CXX=g++
 fi
 
 mkdir build_conda

--- a/pkg/conda/fastfilters/meta.yaml
+++ b/pkg/conda/fastfilters/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   build:
+    - cmake
     - python 2.7*|3.4*|3.5*|3.6*
     - python {{PY_VER}}*
     - numpy

--- a/pkg/conda/fastfilters/meta.yaml
+++ b/pkg/conda/fastfilters/meta.yaml
@@ -20,7 +20,6 @@ build:
 
 requirements:
   build:
-    - gcc 4.8.5 # [linux]
     - python 2.7*|3.4*|3.5*|3.6*
     - python {{PY_VER}}*
     - numpy
@@ -28,7 +27,6 @@ requirements:
     - vigra
 
   run:
-    - libgcc 4.8* # [linux]
     - python {{PY_VER}}*
     - numpy
 

--- a/pkg/conda/fastfilters/meta.yaml
+++ b/pkg/conda/fastfilters/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - gcc 4.8.5 # [unix]
+    - gcc 4.8.5 # [linux]
     - python 2.7*|3.4*|3.5*
     - python {{PY_VER}}*
     - numpy
@@ -28,7 +28,7 @@ requirements:
     - vigra
 
   run:
-    - libgcc 4.8* # [unix]
+    - libgcc 4.8* # [linux]
     - python {{PY_VER}}*
     - numpy
 

--- a/pkg/conda/fastfilters/meta.yaml
+++ b/pkg/conda/fastfilters/meta.yaml
@@ -21,7 +21,7 @@ build:
 requirements:
   build:
     - gcc 4.8.5 # [linux]
-    - python 2.7*|3.4*|3.5*
+    - python 2.7*|3.4*|3.5*|3.6*
     - python {{PY_VER}}*
     - numpy
     - nose


### PR DESCRIPTION
These changes make fastfilters compatible with ilastik's new build stack (native compilers, python 3.6).

BTW, I no longer recommend using the `gcc` and `libgcc` packages from conda, since they're a pain to use, as you know quite well by now.  Instead, we now build Linux binaries with the conda-forge docker container (`condaforge/linux-anvil`), which is basically just a bare CentOS-5 image.  For Mac binaries I use `clang` and `libc++`.