### PR TITLE
Add windows conda package build script

### DIFF
--- a/pkg/conda/fastfilters/bld.bat
+++ b/pkg/conda/fastfilters/bld.bat
@@ -1,0 +1,17 @@
+mkdir build
+cd build
+
+set CONFIGURATION=Release
+
+cmake .. -G "%CMAKE_GENERATOR%" ^
+         -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+         -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+         -DPYTHON_EXECUTABLE="%PYTHON%"
+
+if errorlevel 1 exit 1
+
+cmake --build . --target ALL_BUILD --config %CONFIGURATION%
+if errorlevel 1 exit 1
+
+cmake --build . --target INSTALL --config %CONFIGURATION%
+if errorlevel 1 exit 1


### PR DESCRIPTION
As fastfilters already compiles fine on windows, the only thing missing was a `bld.bat`.