### PR TITLE
Ensure proper AxisType for output channel axis.

### DIFF
--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -28,7 +28,7 @@ def __p_fix_array(func):
 			if res.shape == squeezed.shape:
 				res = vigra.taggedView( res, squeezed.axistags )
 			else:
-				res = vigra.taggedView( res, list(squeezed.axistags) + [vigra.AxisInfo('c')] )
+				res = vigra.taggedView( res, list(squeezed.axistags) + [vigra.AxisInfo('c', vigra.AxisType.Channels)] )
 			return res.withAxes(array.axistags)
 		else:
 			assert not any( np.array(array.shape) == 1 ), \


### PR DESCRIPTION
Apparently `vigra.AxisInfo('c')` will produce an axis tag with `UnknownAxisType`.  The correct axis type is `Channels`.

If the type is not correct, then `res.withAxes(...)` raises an error:

```
VigraArray.withAxes(): array must not contain axes of unknown type (key '?').
```

cc @ilastik